### PR TITLE
Hotfix for Group Scaling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.donnypz</groupId>
     <artifactId>displayentityutils</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <packaging>jar</packaging>
 
     <name>DisplayEntityUtils</name>

--- a/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/DisplayAnimator.java
+++ b/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/DisplayAnimator.java
@@ -46,7 +46,6 @@ public class DisplayAnimator {
     public boolean play(SpawnedDisplayEntityGroup group, int frameIndex){
         if (!new GroupAnimationStartEvent(group, this, animation).callEvent()) {
             return false;
-            //local commit
         }
 
         SpawnedDisplayAnimationFrame frame = animation.frames.get(frameIndex);

--- a/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/DisplayAnimator.java
+++ b/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/DisplayAnimator.java
@@ -46,6 +46,7 @@ public class DisplayAnimator {
     public boolean play(SpawnedDisplayEntityGroup group, int frameIndex){
         if (!new GroupAnimationStartEvent(group, this, animation).callEvent()) {
             return false;
+            //local commit
         }
 
         SpawnedDisplayAnimationFrame frame = animation.frames.get(frameIndex);

--- a/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/SpawnedDisplayEntityGroup.java
+++ b/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/SpawnedDisplayEntityGroup.java
@@ -438,7 +438,7 @@ public final class SpawnedDisplayEntityGroup {
         //Displays
             if (part.type != SpawnedDisplayEntityPart.PartType.INTERACTION){
                 Display d = (Display) part.entity;
-                if (d.getLocation().getChunk().isLoaded()){
+                if (!d.getLocation().getChunk().isLoaded()){
                     return false;
                 }
                 Transformation transformation = d.getTransformation();


### PR DESCRIPTION
- Hotfix for SpawnedDisplayEntityGroup scaling. Inverts a check for a loaded chunk.
- Bump version to 2.2.2