### PR TITLE
2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.donnypz</groupId>
     <artifactId>displayentityutils</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
     <packaging>jar</packaging>
 
     <name>DisplayEntityUtils</name>

--- a/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/DisplayAnimation.java
+++ b/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/DisplayAnimation.java
@@ -7,7 +7,7 @@ public final class DisplayAnimation implements Serializable {
     String animationTag;
     ArrayList<DisplayAnimationFrame> frames = new ArrayList<>();
     String partTag;
-    boolean respectGroupScale = false;
+    boolean respectGroupScale = true;
 
     DisplayAnimation(){}
 

--- a/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/SpawnedDisplayAnimation.java
+++ b/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/SpawnedDisplayAnimation.java
@@ -1,9 +1,9 @@
 package net.donnypz.displayentityutils.utils.DisplayEntities;
 
-import net.donnypz.displayentityutils.DisplayEntityPlugin;
 import net.donnypz.displayentityutils.utils.DisplayUtils;
 import org.bukkit.entity.Display;
 import org.bukkit.entity.Interaction;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,13 +13,16 @@ public final class SpawnedDisplayAnimation {
     String animationTag;
     ArrayList<SpawnedDisplayAnimationFrame> frames = new ArrayList<>();
     String partTag = null;
-    boolean respectGroupScale = false;
+    boolean respectGroupScale = true;
 
+    @ApiStatus.Internal
     public SpawnedDisplayAnimation(){}
 
+    @ApiStatus.Internal
     public SpawnedDisplayAnimation(String partTag){
         this.partTag = partTag;
     }
+
 
     SpawnedDisplayAnimation(SpawnedDisplayEntityGroup group){
         SpawnedDisplayAnimationFrame frame = new SpawnedDisplayAnimationFrame(0, 0);

--- a/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/SpawnedDisplayEntityPart.java
+++ b/src/main/java/net/donnypz/displayentityutils/utils/DisplayEntities/SpawnedDisplayEntityPart.java
@@ -498,11 +498,7 @@ public final class SpawnedDisplayEntityPart {
             long i = 0;
             @Override
             public void run() {
-                if (durationInTicks != -1 && i >= durationInTicks){
-                    cancel();
-                    return;
-                }
-                else if (group.getSpawnedParts().isEmpty() || entity.isDead()){
+                if (entity.isDead() || (durationInTicks != -1 && i >= durationInTicks) || group == null || !group.isSpawned() || group.spawnedParts.isEmpty()){
                     cancel();
                     return;
                 }


### PR DESCRIPTION
- Make Animations respect group scale by default
- Fixes an error where attempting to spawn particles on an invalid group can lead to a server timeout